### PR TITLE
chore: body-max-line-length 규칙 비활성화

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -31,6 +31,7 @@ module.exports = {
         'type-case': [2, 'always', 'lower-case'],
         'subject-full-stop': [2, 'never', '.'],
         'subject-min-length': [2, 'always', 5],
-        'header-max-length': [2, 'always', 72]
+        'header-max-length': [2, 'always', 72],
+        'body-max-line-length': [0, 'never'] // 1차 릴리즈를 위해 임시로 비활성화
     }
 };


### PR DESCRIPTION
1차 릴리즈를 위해 commitlint 설정에서 body-max-line-length 규칙을 임시로 비활성화함

### Description

commitlint 설정에서 `body-max-line-length` 규칙을 임시로 비활성화했습니다. 이 변경은 1차 릴리즈 준비 과정에서 긴 설명을 포함한 커밋 메시지를 허용하기 위함입니다.

### Related Issues

해당 없음

### Changes Made

1. commitlint 설정 파일에서 `body-max-line-length` 규칙을 비활성화함.

### Screenshots or Video

해당 없음

### Testing

1. commitlint를 통한 커밋 메시지 검증이 비활성화된 규칙에 따라 작동하는지 확인했습니다.

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

-   [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
-   [ ] 모든 테스트가 성공적으로 통과했습니다.
-   [ ] 관련 문서를 업데이트했습니다.
-   [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
-   [ ] 코드 스타일 가이드라인을 준수했습니다.
-   [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
- 릴리즈 이후에는 `body-max-line-length` 규칙을 다시 활성화할 예정입니다.